### PR TITLE
feat: support environment variables for test event code field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release Notes for Facebook Conversion
 
+- Improved test event code by supporting as environment variable
+
 ## 1.0.16 - 2022-04-08
 
 - Bugfix: Web Console error on external id

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -50,4 +50,9 @@ class Settings extends Model
     {
         return Craft::parseEnv($this->accessToken);
     }
+
+    public function getTestEventCode(): ?string
+    {
+        return Craft::parseEnv($this->testEventCode);
+    }
 }

--- a/src/services/FacebookBusinessApi.php
+++ b/src/services/FacebookBusinessApi.php
@@ -47,8 +47,9 @@ class FacebookBusinessApi
         $eventRequest = (new EventRequest($settings->getPixelId()))
             ->setEvents([$event]);
 
-        if (!empty($settings->testEventCode)) {
-            $eventRequest->setTestEventCode($settings->testEventCode);
+        $testEventCode = $settings->getTestEventCode();
+        if (!empty($testEventCode)) {
+            $eventRequest->setTestEventCode($testEventCode);
         }
 
         try {


### PR DESCRIPTION
Especially since later Craft CMS version where Project Config files are leading, it would make sense to allow having this setting in an env variable, so that:

1. testing with a test event code won't regenerate project config yaml files
2. testing can be done in environment that don't allow access to plugin settings

It basically brings this field in line with the Pixel ID and Access Token fields.