### PR TITLE
External id performance fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Facebook Conversion
 
+## 1.3.4 - 2024-05-02
+
+- Only generate external id when there is an email address
+- Use lowest blowfish cost for hashing email address to improve performance
+
 ## 1.3.3 - 2024-04-01
 
 - Craft CMS 5 supportgit 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -44,9 +44,9 @@ class Plugin extends BasePlugin
         });
     }
 
-    public function getExternalId($email = null)
+    public function getExternalId($email)
     {
-        return Craft::$app->getSecurity()->generatePasswordHash('fb_' . $email);
+        return Craft::$app->getSecurity()->generatePasswordHash('fb_' . $email, 1);
     }
 
     protected function createSettingsModel(): ?Model

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -46,7 +46,7 @@ class Plugin extends BasePlugin
 
     public function getExternalId($email)
     {
-        return Craft::$app->getSecurity()->generatePasswordHash('fb_' . $email, 1);
+        return Craft::$app->getSecurity()->generatePasswordHash('fb_' . $email, 4);
     }
 
     protected function createSettingsModel(): ?Model

--- a/src/hooks/HeadTag.php
+++ b/src/hooks/HeadTag.php
@@ -25,9 +25,8 @@ class HeadTag
                 ->getCart()
                 ->getEmail();
 
-            $externalId = $plugin->getExternalId($email);
-
             if ($email) {
+                $externalId = $plugin->getExternalId($email);
                 $options = ", {'external_id': '{$externalId}'}";
             }
         }

--- a/src/twig/TwigExtension.php
+++ b/src/twig/TwigExtension.php
@@ -33,6 +33,6 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
 
     public function getOperators(): array
     {
-        return [];
+        return [[], []];
     }
 }


### PR DESCRIPTION
- Only generate external id when there is an email address 
- Use lowest blowfish cost for hashing email address to improve performance